### PR TITLE
Use deviceOrientation when recording

### DIFF
--- a/ios/EXCamera/EXCamera.m
+++ b/ios/EXCamera/EXCamera.m
@@ -446,7 +446,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [self updateSessionAudioIsMuted:shouldBeMuted];
 
     AVCaptureConnection *connection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-    [connection setVideoOrientation:[EXCameraUtils videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]]];
+    [connection setVideoOrientation:[EXCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
 
     EX_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "expo-core": "^1.0.1",
     "expo-camera-interface": "^1.0.1",
-    "expo-barcode-scanner-interface": "^1.0.0",
+    "expo-barcode-scanner-interface": "*",
     "expo-file-system-interface": "^1.0.1",
     "expo-face-detector-interface": "^1.0.1",
     "expo-permissions-interface": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "expo-core": "^1.0.1",
     "expo-camera-interface": "^1.0.1",
-    "expo-barcode-scanner-interface": "*",
+    "expo-barcode-scanner-interface": "^1.0.0",
     "expo-file-system-interface": "^1.0.1",
     "expo-face-detector-interface": "^1.0.1",
     "expo-permissions-interface": "^1.0.1",


### PR DESCRIPTION
We should use device orientation to set the captureSession orientation.  This is how it's done in the takePicture as well.

